### PR TITLE
代码逻辑补充和功能修复。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# JetBrains Pycharm user/project files
+.idea
+
 **/__pycache__
 *.mid
 *.exe

--- a/packages/Ideal Piano start program.pyw
+++ b/packages/Ideal Piano start program.pyw
@@ -3,8 +3,11 @@ import sys
 
 abs_path = os.path.dirname(os.path.abspath(__file__))
 os.chdir(abs_path)
-sys.path.insert(0, abs_path)
+if abs_path.split("\\")[-1] == "packages":
+    os.chdir("../")
+sys.path.insert(0, os.getcwd())
 sys.path.insert(0, 'packages')
+sys.path.insert(0, 'resources')
 import fractions
 import pygame
 import pygame.midi

--- a/packages/Ideal Piano.pyw
+++ b/packages/Ideal Piano.pyw
@@ -340,7 +340,6 @@ class piano_window(pyglet.window.Window):
 
     def init_layers(self):
         self.batch = pyglet.graphics.Batch()
-        pyglet_main_version = int(pyglet.version[0])
         if pyglet_main_version >= 2:
             self.bottom_group = pyglet.graphics.Group(order=0)
             self.piano_bg = pyglet.graphics.Group(order=1)
@@ -1863,11 +1862,18 @@ class piano_engine:
                     self.stillplay = []
 
     def _pc_read_pc_keyboard_key(self):
-        self.current = [
-            current_piano_window.map_key_dict_reverse[i]
-            for i, j in current_piano_window.keyboard_handler.data.items()
-            if j and i in current_piano_window.map_key_dict_reverse
-        ]
+        if pyglet_main_version >= 2:
+            self.current = [
+                current_piano_window.map_key_dict_reverse[i]
+                for i, j in current_piano_window.keyboard_handler.data.items()
+                if j and i in current_piano_window.map_key_dict_reverse
+            ]
+        else:
+            self.current = [
+                current_piano_window.map_key_dict_reverse[i]
+                for i, j in current_piano_window.keyboard_handler.items()
+                if j and i in current_piano_window.map_key_dict_reverse
+            ]
         self.current = [i for i in self.current if i in self.wavdic]
         if piano_config.delay:
             self.stillplay_obj = [x[0] for x in self.stillplay]
@@ -2626,6 +2632,7 @@ class piano_engine:
 
 
 if __name__ == '__main__':
+    pyglet_main_version = int(pyglet.version[0])
     multiprocessing.freeze_support()
     if sys.platform == 'darwin':
         try:

--- a/packages/Ideal Piano.pyw
+++ b/packages/Ideal Piano.pyw
@@ -340,11 +340,19 @@ class piano_window(pyglet.window.Window):
 
     def init_layers(self):
         self.batch = pyglet.graphics.Batch()
-        self.bottom_group = pyglet.graphics.OrderedGroup(0)
-        self.piano_bg = pyglet.graphics.OrderedGroup(1)
-        self.piano_key = pyglet.graphics.OrderedGroup(2)
-        self.play_highlight = pyglet.graphics.OrderedGroup(3)
-        self.piano_keys_note_name = pyglet.graphics.OrderedGroup(4)
+        pyglet_main_version = int(pyglet.version[0])
+        if pyglet_main_version >= 2:
+            self.bottom_group = pyglet.graphics.Group(order=0)
+            self.piano_bg = pyglet.graphics.Group(order=1)
+            self.piano_key = pyglet.graphics.Group(order=2)
+            self.play_highlight = pyglet.graphics.Group(order=3)
+            self.piano_keys_note_name = pyglet.graphics.Group(order=4)
+        else:
+            self.bottom_group = pyglet.graphics.OrderedGroup(0)
+            self.piano_bg = pyglet.graphics.OrderedGroup(1)
+            self.piano_key = pyglet.graphics.OrderedGroup(2)
+            self.play_highlight = pyglet.graphics.OrderedGroup(3)
+            self.piano_keys_note_name = pyglet.graphics.OrderedGroup(4)
 
     def init_note_mode(self):
         current_piano_engine.plays = []
@@ -1857,7 +1865,7 @@ class piano_engine:
     def _pc_read_pc_keyboard_key(self):
         self.current = [
             current_piano_window.map_key_dict_reverse[i]
-            for i, j in current_piano_window.keyboard_handler.items()
+            for i, j in current_piano_window.keyboard_handler.data.items()
             if j and i in current_piano_window.map_key_dict_reverse
         ]
         self.current = [i for i in self.current if i in self.wavdic]


### PR DESCRIPTION
Ideal Piano start program.pyw:
新增逻辑判断工作路径是否正确。
Ideal Piano.pyw:
在init_layers()中新增对pyglet>=2.0的支持
在_pc_read_pc_keyboard_key()中，修复因缺失.data成员访问导致的current_piano_window.keyboard_handler键值对遍历错误。 gitignore:
忽略Pycharm产生的用户项目设置文件